### PR TITLE
Name previously unnamed BT nodes

### DIFF
--- a/gen_movement.py
+++ b/gen_movement.py
@@ -50,7 +50,7 @@ def move_to(target: np.array, agent:Agent, name: None|str = None) -> BTNode:
         targets = list(map(lambda x: x - position, targets))
         displacement = shorstest_vect(targets) 
         if np.linalg.norm(displacement) == 0:
-             return LOGIC(lambda x: True)  
+             return LOGIC(lambda x: True, "already at target")
         
                        
         ### movement in x
@@ -204,7 +204,10 @@ def marco_polo_follower(agent: Agent):
     scream = ct.GEN(gtem.ready_for_incantation, name = "scream I arrived")
     step3 = ct.ALWAYS_F(move, "move Success does not mean we are there")
     step2 = ct.OR([ct.AND([am_i_there,scream], "if we are there scream"), step3], "if we are not there move ")
-    step1 = ct.OR([ct.AND([do_i_have_direction,step2]),ct.ALWAYS_F(gen_interaction("inventaire"), "fallback marco polo step")],name = "Marco follower main node")
+    step1 = ct.OR([
+        ct.AND([do_i_have_direction,step2], name="have direction then move"),
+        ct.ALWAYS_F(gen_interaction("inventaire"), "fallback marco polo step")
+    ],name = "Marco follower main node")
 
     
     return step1

--- a/gen_teaming.py
+++ b/gen_teaming.py
@@ -48,7 +48,7 @@ def disband(x, reason = ""):
     message["reason"] = reason
     x.party.reset_party()
     if ret == 0:
-        return ct.LOGIC(lambda x: True, "True")
+        return ct.LOGIC(lambda x: True, "no party to disband")
     x.alive_processer(json.dumps(message))
     return gen_interaction("broadcast",json.dumps(message))
 
@@ -106,21 +106,22 @@ did_i_do_it =  ct.LOGIC(lambda x: x.party.party_closed and len(x.party.party_inv
 
 #party_lead_closed = ct.AND() #step0
 step1 = ct.AND([am_i_leader,ct.GEN(lfg_gen, name = "lfg generator"),
-                ct.LOGIC(lambda x:False, "False")  ], name = "join step leader spam lfg")
+                ct.LOGIC(lambda x:False, "always false placeholder")  ], name = "join step leader spam lfg")
 
 
 step2 = ct.AND([is_party_not_closed_can_close,ct.GEN(closed_party_gen, name = "closed party generator"),
-                 ct.LOGIC(lambda x:False, "False")], name = "close party condition ok")
+                 ct.LOGIC(lambda x:False, "always false placeholder")], name = "close party condition ok")
 
-stale_check = ct.OR([ ct.LOGIC(lambda x: x.turn - x.party.party_join_timeout < 30),
-                     ct.LOGIC(lambda x: (x.party.reset_party(),False)[1])
+stale_check = ct.OR([
+    ct.LOGIC(lambda x: x.turn - x.party.party_join_timeout < 30, name="join timeout ok"),
+    ct.LOGIC(lambda x: (x.party.reset_party(),False)[1], name="join timeout exceeded reset")
 ],"stale join party checks")
 
 
-step3 = ct.AND([ do_i_join,stale_check,  ct.GEN(join_party_gen, name = "Join party generator"), ct.LOGIC(lambda x:False, "False")], name="joining logic")
+step3 = ct.AND([ do_i_join,stale_check,  ct.GEN(join_party_gen, name = "Join party generator"), ct.LOGIC(lambda x:False, "always false placeholder")], name="joining logic")
 
 
-step4 = ct.AND([do_i_share_inv,ct.GEN(share_inventory, name = "share inventory generator"), ct.LOGIC(lambda x:False, "False")], name = "sync inv")
+step4 = ct.AND([do_i_share_inv,ct.GEN(share_inventory, name = "share inventory generator"), ct.LOGIC(lambda x:False, "always false placeholder")], name = "sync inv")
 
 
 teaming = ct.OR([step1,step2, step3, step4, did_i_do_it], name = "teaming main selector")

--- a/master_plan.py
+++ b/master_plan.py
@@ -28,14 +28,14 @@ hunger_party = ct.GATE(open_cond= open_cond,close_cond=close_cond, name="open hu
 
 hungry_party = ct.AND([
         hunger_party,
-        ct.GEN(lambda x: gtem.disband(x, reason = "I am hungry")),
-])
+        ct.GEN(lambda x: gtem.disband(x, reason = "I am hungry"), name="hungry disband generator"),
+], name="hungry party disband")
 
 
 
 
-find_food_vector = [ ct.OR([hungry_party , hunger_not_party],"conditions to find food"), 
-                     (ct.OR([ct.GEN(lambda x: ggat.pick_up(x,"nourriture"),"pick up food generator")]))]
+find_food_vector = [ ct.OR([hungry_party , hunger_not_party],"conditions to find food"),
+                     (ct.OR([ct.GEN(lambda x: ggat.pick_up(x,"nourriture"),"pick up food generator")], name="single pick up food"))]
 
 find_food = ct.AND(find_food_vector, name = "find_food")
 
@@ -51,17 +51,21 @@ level_up = ct.GEN(lambda x: ggat.level_up(x), name = "level up main", reset_on_f
 #gooble = ct.AND([ct.LOGIC(lambda x: np.array_equal(ggat.closest_resource(x,"nourriture"),x.pos ) ), gen_interaction("prend", "nourriture") ], name = "oportunistic food")
 
 am_I_almost_declared_dead = ct.AND([ct.LOGIC(lambda x: x.turn - x.ppl_timeouts.get(x.name,x.turn)  >= 350, "am I missing?"),
-                                    ct.GEN(gtem.share_inventory)
-                                    ])
+                                    ct.GEN(gtem.share_inventory, name="share inventory generator")
+                                    ], name="am I almost declared dead")
 
 
 
 #######
 p_lay_egg = 0.002
-lay_an_egg =ct.GEN(lambda _: ct.AND_P([ct.LOGIC(lambda x: random.random()< p_lay_egg and len(x.ppl_lv)<12 and x.level > 1),
-                    gen_interaction("fork")
-                    ])
-                    )
+lay_an_egg = ct.GEN(
+    lambda _: ct.AND_P([
+        ct.LOGIC(lambda x: random.random() < p_lay_egg and len(x.ppl_lv) < 12 and x.level > 1,
+                  "should lay egg"),
+        gen_interaction("fork")
+    ], name="lay egg sequence"),
+    name="lay an egg generator"
+)
 
 
 


### PR DESCRIPTION
## Summary
- add explicit names to party hunger, disband, and egg-laying nodes
- label resource gathering and quorum-checking behavior tree nodes for debugging clarity
- clarify teaming and movement nodes with descriptive placeholders

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a85861d18c832889f07afeb8eef634